### PR TITLE
Update mapster.js

### DIFF
--- a/src/mapster.js
+++ b/src/mapster.js
@@ -18,7 +18,8 @@
       this.markers = List.create();
 
       if (opts.cluster) {
-        this.markerClusterer = new MarkerClusterer(this.gMap, [], { ignoreHidden: true } );
+        var clusterOpts = opts.cluster.options ? opts.cluster.options : { ignoreHidden: true };
+        this.markerClusterer = new MarkerClusterer(this.gMap, [], clusterOpts );
       }
 
       if (opts.geocoder) {


### PR DESCRIPTION
Allow us to pass in an options object on Mapster init. Defaults to {ignoreHidden:true}
